### PR TITLE
Allow override of sane default listening address

### DIFF
--- a/source/main.d
+++ b/source/main.d
@@ -18,14 +18,14 @@ module main;
 import libsodium : sodium_init;
 import moss.service.context;
 import moss.service.models;
-import std.conv : to;
-import std.path : absolutePath, asNormalizedPath;
-import summit.models;
 import moss.service.server;
-import vibe.d;
-import summit.app;
-import summit.setup;
+import std.conv : to;
 import std.getopt;
+import std.path : absolutePath, asNormalizedPath;
+import summit.app;
+import summit.models;
+import summit.setup;
+import vibe.d;
 
 /**
  * Main entry for summit
@@ -37,11 +37,13 @@ import std.getopt;
 int main(string[] args) @safe
 {
     ushort portNumber = 8081;
-    string[] addresses = ["::", "0.0.0.0"];
+    /* It's safer to set this to localhost and allow the user to override (not append!) */
+    static string[] defaultAddress = ["localhost"];
+    string[] cmdLineAddresses;
 
     auto opts = () @trusted {
         return getopt(args, config.bundling, "p|port", "Specific port to serve on",
-                &portNumber, "a|address", "Host address to bind to", &addresses);
+                &portNumber, "a|address", "Host address to bind to", &cmdLineAddresses);
     }();
 
     if (opts.helpWanted)
@@ -60,7 +62,7 @@ int main(string[] args) @safe
     {
         server.close();
     }
-    server.serverSettings.bindAddresses = addresses;
+    server.serverSettings.bindAddresses = cmdLineAddresses.empty ? defaultAddress : cmdLineAddresses;
     server.serverSettings.port = portNumber;
     server.serverSettings.serverString = "summit/0.0.1";
     server.serverSettings.sessionIdCookie = "summit.session_id";


### PR DESCRIPTION
This commit makes the service listen on localhost by default when no address command line parameters are specified.

If any address command line parameters are specified, they will be added to an initially empty dynamic address array in the listed order, thus overriding the default listening address.