### PR TITLE
Display validation errors in setup form

### DIFF
--- a/source/summit/setup.d
+++ b/source/summit/setup.d
@@ -51,9 +51,17 @@ public final class SetupApplication : Application
      * Real index page
      */
     @path("setup") @method(HTTPMethod.GET)
-    void setupIndex() @safe
+    void setupIndex(FormError _error = FormError.init, string instanceURI = null,
+            string description = null, string username = null, string emailAddress = null) @safe
     {
-        render!"setup/index.dt";
+        /* Throw internal error if not from field validation */
+        if (!_error.error.empty && _error.field.empty)
+        {
+            throw new HTTPStatusException(HTTPStatus.internalServerError, _error.error);
+
+        }
+
+        render!("setup/index.dt", _error, instanceURI, description, username, emailAddress);
     }
 
     /**
@@ -67,8 +75,9 @@ public final class SetupApplication : Application
      *      password = Admin password
      *      confirmPassword = Confirmation that password matches
      */
-    @path("setup/apply") @method(HTTPMethod.POST) void applySetup(string instanceURI,
-            string description, ValidUsername username,
+    @path("setup") @method(HTTPMethod.POST) @errorDisplay!setupIndex void applySetup(
+            string instanceURI, string description,
+            ValidUsername username,
             ValidEmail emailAddress, ValidPassword password, Confirm!"password" confirmPassword) @sanitizeUTF8
     {
         Settings appSettings;
@@ -113,4 +122,10 @@ private:
 
     URLRouter _router;
     ServiceContext context;
+}
+
+private struct FormError
+{
+    string error;
+    string field;
 }

--- a/source/summit/setup.d
+++ b/source/summit/setup.d
@@ -54,12 +54,8 @@ public final class SetupApplication : Application
     void setupIndex(FormError _error = FormError.init, string instanceURI = null,
             string description = null, string username = null, string emailAddress = null) @safe
     {
-        /* Throw internal error if not from field validation */
-        if (!_error.error.empty && _error.field.empty)
-        {
-            throw new HTTPStatusException(HTTPStatus.internalServerError, _error.error);
-
-        }
+        /* Throw internal error if not a field validation error */
+        enforceHTTP(_error.isValid, HTTPStatus.internalServerError, _error.error);
 
         render!("setup/index.dt", _error, instanceURI, description, username, emailAddress);
     }
@@ -128,4 +124,14 @@ private struct FormError
 {
     string error;
     string field;
+
+    /**
+     * Returns true if the error is empty or a field validation error.
+     *
+     * Valid errors are safe to forward to a Diet template.
+     */
+    pure @property bool isValid() @safe
+    {
+        return error.empty || !field.empty;
+    }
 }

--- a/views/setup/index.dt
+++ b/views/setup/index.dt
@@ -16,7 +16,16 @@ block body
                     div.text-center.row.p-1: p.lead.opacity-75 Summit is a dashboard and controller for the Serpent OS build infrastructure. With it, packages are automatically scheduled across various builders for build and inclusion in repositories.
                     div.text-center.row.p-1: p.lead We just need to go through some basic details before we can get everything up and running.
 
-                    form#setupForm(autocomplete="off", action="/setup/apply", method="POST")
+                    - string formClass(string field)
+                        - return _error.field == field ? "form-control is-invalid" : "form-control";
+
+                    - void fieldError(string field)
+                        - if(_error.field == field) {
+                            div.is-invalid
+                            div.invalid-feedback #{_error.error}
+                        - }
+
+                    form#setupForm(autocomplete="off", action="/setup", method="POST")
                         input(type="hidden", autocomplete="off")
                         div.container.pt-2
                             div.row.p-2
@@ -27,13 +36,13 @@ block body
                                             label.opacity-75.form-label(for="instanceURI") Public URL
                                             div.input-icon
                                                 span.input-icon-addon: svg.icon: use(xlink:href="/static/tabler/tabler-sprite.svg#tabler-link")
-                                                input#instanceURI.form-control(name="instanceURI", type="text", placeholder="https://somehost:8082", required, minlength="4", value=req.fullURL.toString[0..$-"/setup".length])
+                                                input#instanceURI.form-control(name="instanceURI", type="text", placeholder="https://somehost:8082", required, minlength="4", value=instanceURI ? instanceURI : req.fullURL.toString[0..$-"/setup".length])
                                     div.row.mb-2
                                         div
                                             label.opacity-75.form-label(for="description") Description
                                             div.input-icon
                                                 span.input-icon-addon: svg.icon: use(xlink:href="/static/tabler/tabler-sprite.svg#tabler-ballpen")
-                                                input#description.form-control(name="description", type="text", placeholder="Unique public description", required, minlength="4")
+                                                input#description.form-control(name="description", type="text", placeholder="Unique public description", required, minlength="4", value=description)
 
                                 div.col-lg-6.col-md-12.px-4
                                     div.row.py-2: h3 Administrator
@@ -42,25 +51,29 @@ block body
                                         div
                                             div.input-icon
                                                 span.input-icon-addon: svg.icon: use(xlink:href="/static/tabler/tabler-sprite.svg#tabler-user")
-                                                input#username.form-control(name="username", type="text", placeholder="Pick a unique username", required, minlength="4")
+                                                input#username(class=formClass("username"), name="username", type="text", placeholder="Pick a unique username", required, minlength="4", value=username)
+                                            - fieldError("username");
                                     div.row.mb-2
                                         label.opacity-75.form-label(for="email") Email address
                                         div
                                             div.input-icon
                                                 span.input-icon-addon: svg.icon: use(xlink:href="/static/tabler/tabler-sprite.svg#tabler-mail")
-                                                input#emailAddress.form-control(name="emailAddress", type="email", placeholder="me@example.com", required)
+                                                input#emailAddress(class=formClass("emailAddress"), name="emailAddress", type="email", placeholder="me@example.com", required, value=emailAddress)
+                                            - fieldError("emailAddress");
                                     div.row.mb-2
                                         label.opacity-75.form-label(for="password") Password
                                         div
                                             div.input-icon
                                                 span.input-icon-addon: svg.icon: use(xlink:href="/static/tabler/tabler-sprite.svg#tabler-lock")
-                                                input#password.form-control(name="password", type="password", placeholder="Type your password", required, minlength="6")
+                                                input#password.form-control(class=formClass("password"), name="password", type="password", placeholder="Type your password", required, minlength="6")
+                                            - fieldError("password");
                                     div.row.mb-2
                                         label.opacity-75.form-label(for="confirmPassword") Confirm password
                                         div
                                             div.input-icon
                                                 span.input-icon-addon: svg.icon: use(xlink:href="/static/tabler/tabler-sprite.svg#tabler-lock")
-                                                input#confirmPassword.form-control(name="confirmPassword", type="password", placeholder="And confirm your password", required, minlength="6")
+                                                input#confirmPassword.form-control(class=formClass("confirmPassword"), name="confirmPassword", type="password", placeholder="And confirm your password", required, minlength="6")
+                                            - fieldError("confirmPassword");
 
                 div.card-footer
                     div.d-flex


### PR DESCRIPTION
This routes any form validation error & existing form values back into the rendered page for better UX when submitting the setup form.

I mainly tackled this as a way to dip my toes into `D` and `diet`, but this can serve as an example of handling server rendered form validation for other forms if needed.

Notable changes:

- `/setup` is used for `POST` (this change isn't necessary for this to work, just preference)
- `errorDisplay` is used to route validation errors back to the `setupIndex` handler, so we can `render` the page w/ the error
- Applicable form fields are added to `setupIndex` / `render` so they're remembered when an error occurs 
- Diet file is updated to pre-populate form values if provided and display error on the applicable field 


https://user-images.githubusercontent.com/10239377/233202512-aef968d9-44a3-4c70-9bd8-99a96b760cca.mp4



