### PR TITLE
fixtures: Forcibly sync the URIs from fixtures when changed

### DIFF
--- a/source/summit/fixtures.d
+++ b/source/summit/fixtures.d
@@ -89,6 +89,14 @@ static void loadFixtures(ServiceContext context, ProjectManager projectManager) 
             auto l = project.bySlug(repo.name);
             if (l !is null)
             {
+                // Check if URI needs updating
+                if (l.model.originURI != repo.uri)
+                {
+                    auto m = l.model;
+                    m.originURI = repo.uri;
+                    immutable err = project.updateRepository(m);
+                    enforceHTTP(err.isNull, HTTPStatus.internalServerError, err.message);
+                }
                 continue;
             }
             Repository r;
@@ -105,6 +113,14 @@ static void loadFixtures(ServiceContext context, ProjectManager projectManager) 
             auto l = project.profile(profile.name);
             if (l !is null)
             {
+                // Check if URI needs updating
+                if (l.profile.volatileIndexURI != profile.indexURI)
+                {
+                    auto m = l.profile;
+                    m.volatileIndexURI = profile.indexURI;
+                    immutable err = project.updateProfile(m);
+                    enforceHTTP(err.isNull, HTTPStatus.internalServerError, err.message);
+                }
                 continue;
             }
 

--- a/source/summit/projects/project.d
+++ b/source/summit/projects/project.d
@@ -36,7 +36,7 @@ public final class ManagedProject
 {
     @disable this();
 
-    /** 
+    /**
      * Construct a new ManagedProject
      *
      * Params:
@@ -75,7 +75,7 @@ public final class ManagedProject
         return managedProfiles.values;
     }
 
-    /** 
+    /**
      * Returns: Repository within this project
      *
      * Params:
@@ -161,6 +161,34 @@ public final class ManagedProject
     }
 
     /**
+     * Update a repository in this project
+     *
+     * Params:
+     *      model = Input model
+     * Returns: Nullable database error
+     */
+    DatabaseResult updateRepository(Repository model) @safe
+    {
+        /* Try to store the model */
+        immutable err = context.appDB.update((scope tx) => model.save(tx));
+        if (!err.isNull)
+        {
+            return err;
+        }
+
+        /* Get it managed */
+        auto managedRepository = managedRepos.get(model.name, null);
+        if (managedRepository is null)
+        {
+            return DatabaseResult(DatabaseError(DatabaseErrorCode.BucketNotFound,
+                    "Repository not found"));
+        }
+
+        runTask({ managedRepository.refresh(); });
+        return NoDatabaseError;
+    }
+
+    /**
      * Add a profile to this project
      *
      *      model = Input model
@@ -191,6 +219,34 @@ public final class ManagedProject
             return NoDatabaseError;
         }, (Failure f) => DatabaseResult(DatabaseError(cast(DatabaseErrorCode) f.specifier,
                 f.message)));
+    }
+
+    /**
+     * Update a profile in this project
+     *
+     * Params:
+     *      model = Input model
+     * Returns: Nullable database error
+     */
+    DatabaseResult updateProfile(Profile model) @safe
+    {
+        /* Try to store the model */
+        immutable err = context.appDB.update((scope tx) => model.save(tx));
+        if (!err.isNull)
+        {
+            return err;
+        }
+
+        /* Get it managed */
+        auto managedProfile = managedProfiles.get(model.name, null);
+        if (managedProfile is null)
+        {
+            return DatabaseResult(DatabaseError(DatabaseErrorCode.BucketNotFound,
+                    "Profile not found"));
+        }
+
+        runTask({ managedProfile.refresh(); });
+        return NoDatabaseError;
     }
 
 package:


### PR DESCRIPTION
This permits a quick and easy transition away from our existing subdomains to the new packages.serpentos.com one.